### PR TITLE
Add option to install circlci-cli completions.

### DIFF
--- a/src/circleci-cli/devcontainer-feature.json
+++ b/src/circleci-cli/devcontainer-feature.json
@@ -13,6 +13,11 @@
             "default": "/usr/local/bin/",
             "description": "Filesystem location of the circleci binary.",
             "type": "string"
+        },
+        "completions": {
+            "default": true,
+            "description": "Attempt to install shell completions for bash & zsh.",
+            "type": "boolean"
         }
     },
     "customizations": {

--- a/src/circleci-cli/install.sh
+++ b/src/circleci-cli/install.sh
@@ -27,6 +27,17 @@ check_packages() {
 }
 
 export DEBIAN_FRONTEND=noninteractive
-check_packages curl ca-certificates
+check_packages curl ca-certificates bash-completion
 
 curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | bash
+
+if [ "$COMPLETIONS" = "true" ]; then {
+    # circleci bash completion
+    mkdir -p /etc/bash_completion.d
+    circleci completion bash > /etc/bash_completion.d/circleci
+
+    # circleci zsh completion
+    if [ -e "/usr/share/zsh/vendor-completions" ]; then
+        circleci completion zsh > /usr/share/zsh/vendor-completions/_circleci
+    fi
+} fi


### PR DESCRIPTION
Forcefully installs bash completions at `/etc/bash_completion.d/circleci`.

Gracefully installs zsh completions at `/usr/share/zsh/vendor-completions/_circleci`.
